### PR TITLE
ci: parallelize sis-scraper and prereq-scraper to reduce job times

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -87,11 +87,15 @@ jobs:
           name: schools
           path: data
 
-      - name: Scrape courses
-        run: python3 sis_scraper/main.py
-
-      - name: Scrape prerequisites
-        run: python3 prerequisites_scraper/main.py
+      - name: Scrape courses & prerequesites
+        run: |
+         python3 sis_scraper/main.py&
+         PID1=$!
+         python3 prerequisites_scraper/main.py&
+         PID2=$!
+         set -e
+         wait $PID1
+         wait $PID2
 
       - name: Upload data
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
Currently sis-scraper with all optimizations on takes around ~1min 40 seconds to run.
The prereq scraper is variable but tends to run anywhere from ~2minutes to 6minutes.

This change modifies scrape courses and prereqs action to run these jobs in parallel, as the prereq scraper is mostly I/O bound while the sis scraper is CPU bound.

This should produce a max(runtime(sis_scraper), runtime(prereq-scraper)) runtime (approx) instead of stacking them